### PR TITLE
Feat/register/UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-radio-group": "^1.3.4",
         "@radix-ui/react-slot": "^1.2.0",
         "@tailwindcss/vite": "^4.1.4",
+        "@tanstack/react-query": "^5.75.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.503.0",
@@ -28,6 +29,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
+        "@tanstack/eslint-plugin-query": "^5.74.7",
         "@types/node": "^22.14.1",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
@@ -1846,6 +1848,46 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query": {
+      "version": "5.74.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.74.7.tgz",
+      "integrity": "sha512-EeHuaaYiCOD+XOGyB7LMNEx9OEByAa5lkgP+S3ZggjKJpmIO6iRWeoIYYDKo2F8uc3qXcVhTfC7pn7NddQiNtA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.18.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.75.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.75.0.tgz",
+      "integrity": "sha512-rk8KQuCdhoRkzjRVF3QxLgAfFUyS0k7+GCQjlGEpEGco+qazJ0eMH6aO1DjDjibH7/ik383nnztua3BG+lOnwg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.75.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.75.1.tgz",
+      "integrity": "sha512-tN+gG+eXCHYm+VpmdXUP1rfE9LUrRzgYozTkBZtJV1/WFM3vwWNKQC8G6b2RKcs+2cPg+hdToZHZfjL3bF4yIQ==",
+      "dependencies": {
+        "@tanstack/query-core": "5.75.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
+        "@radix-ui/react-checkbox": "^1.2.3",
         "@radix-ui/react-label": "^2.1.4",
+        "@radix-ui/react-radio-group": "^1.3.4",
         "@radix-ui/react-slot": "^1.2.0",
         "@tailwindcss/vite": "^4.1.4",
         "class-variance-authority": "^0.7.1",
@@ -997,10 +999,114 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+      "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA=="
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.2.3.tgz",
+      "integrity": "sha512-pHVzDYsnaDmBlAuwim45y3soIN8H4R7KbkSVirGhXO+R/kO2OLCe0eucUEbddaTcdMHHdzcIGHtZSMSQlA+apw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.0",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.4.tgz",
+      "integrity": "sha512-cv4vSf7HttqXilDnAnvINd53OTl1/bjUYVZrkFnA7nwmY9Ob2POUy0WY0sfqBAe1s5FyKsyceQlqiEGPYNTadg==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.0",
+        "@radix-ui/react-slot": "1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
       "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1017,6 +1123,29 @@
       "integrity": "sha512-wy3dqizZnZVV4ja0FNnUhIWNwWdoldXrneEyUcVtLYDAt8ovGS4ridtMAOGgXBBIfggL4BOveVWsjXDORdGEQg==",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+      "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1055,12 +1184,167 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.4.tgz",
+      "integrity": "sha512-N4J9QFdW5zcJNxxY/zwTXBN4Uc5VEuRM7ZLjNfnWoKmNvgrPtNNw4P8zY532O3qL6aPkaNO+gY9y6bfzmH4U1g==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.0",
+        "@radix-ui/react-roving-focus": "1.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.7.tgz",
+      "integrity": "sha512-C6oAg451/fQT3EGbWHbCQjYTtbyjNO1uzQgMzwyivcHT3GKNEmu1q3UuREhN+HzHAVtv3ivMVK08QlC+PkYw9Q==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.0",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.0.tgz",
       "integrity": "sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-radio-group": "^1.3.4",
     "@radix-ui/react-slot": "^1.2.0",
     "@tailwindcss/vite": "^4.1.4",
+    "@tanstack/react-query": "^5.75.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.503.0",
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
+    "@tanstack/eslint-plugin-query": "^5.74.7",
     "@types/node": "^22.14.1",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
+    "@radix-ui/react-checkbox": "^1.2.3",
     "@radix-ui/react-label": "^2.1.4",
+    "@radix-ui/react-radio-group": "^1.3.4",
     "@radix-ui/react-slot": "^1.2.0",
     "@tailwindcss/vite": "^4.1.4",
     "class-variance-authority": "^0.7.1",

--- a/src/features/register/model/schema.ts
+++ b/src/features/register/model/schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+const registerSchema = z.object({
+  isReceived: z.string(),
+  patientId: z.string(),
+  patientName: z.string(),
+  isMale: z.boolean(),
+  birthday: z.string(),
+  operationDate: z.string(),
+});
+
+export default registerSchema;

--- a/src/features/register/model/schema.ts
+++ b/src/features/register/model/schema.ts
@@ -4,7 +4,7 @@ const registerSchema = z.object({
   isReceived: z.string(),
   patientId: z.string(),
   patientName: z.string(),
-  isMale: z.boolean(),
+  isMale: z.string(),
   birthday: z.string(),
   operationDate: z.string(),
 });

--- a/src/features/register/model/type.ts
+++ b/src/features/register/model/type.ts
@@ -3,4 +3,23 @@ import registerSchema from "./schema";
 
 export type registerSchema = z.infer<typeof registerSchema>;
 
-export const steps = ["first", "second", "thired"] as const;
+export const STEP = {
+  FIRST: "first",
+  SECOND: "second",
+  THIRD: "third",
+};
+
+export const steps = [STEP.FIRST, STEP.SECOND, STEP.THIRD] as (
+  | "first"
+  | "second"
+  | "third"
+)[];
+
+export const stepField: Record<
+  (typeof steps)[number],
+  (keyof z.infer<typeof registerSchema>)[]
+> = {
+  first: ["isReceived"],
+  second: ["patientId", "patientName", "isMale", "birthday", "operationDate"],
+  third: [],
+};

--- a/src/features/register/model/type.ts
+++ b/src/features/register/model/type.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+import registerSchema from "./schema";
+
+export type registerSchema = z.infer<typeof registerSchema>;
+
+export const steps = ["first", "second", "thired"] as const;

--- a/src/features/register/model/useFunnel.tsx
+++ b/src/features/register/model/useFunnel.tsx
@@ -1,0 +1,34 @@
+import React, { ReactElement, ReactNode, useState } from "react";
+
+export interface StepProps {
+  name: string;
+  children: ReactNode;
+}
+
+export interface FunnelProps {
+  children: Array<ReactElement<StepProps>>;
+}
+
+export const useFunnel = (defaultStep: string) => {
+  // state를 통해 현재 스텝을 관리한다.
+  // setStep 함수를 통해 현재 스텝을 변경할 수 있다.
+  const [step, setStep] = useState(defaultStep);
+
+  // 각 단계를 나타내는 Step 컴포넌트
+  // children을 통해 각 스텝의 컨텐츠를 렌더링 한다.
+  const Step = (props: StepProps): ReactElement => {
+    return <>{props.children}</>;
+  };
+
+  // 여러 단계의 Step 컴포넌트 중 현재 활성화된 스텝을 렌더링하는 Funnel
+  // find를 통해 Step 중 현재 Step을 찾아 렌더링
+  const Funnel = ({ children }: FunnelProps) => {
+    const targetStep = children.find(
+      (childStep) => childStep.props.name === step
+    );
+
+    return <>{targetStep}</>;
+  };
+
+  return { Funnel, Step, setStep, currentStep: step } as const;
+};

--- a/src/features/register/model/useStepForm.tsx
+++ b/src/features/register/model/useStepForm.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+
+const useStepForm = <T extends string>(steps: T[]) => {
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+
+  const next = () => {
+    setCurrentStepIndex((prev) => Math.min(prev + 1, steps.length - 1));
+  };
+
+  const back = () => {
+    setCurrentStepIndex((prev) => Math.max(prev - 1, 0));
+  };
+
+  const reset = () => setCurrentStepIndex(0);
+
+  const currentStep = steps[currentStepIndex];
+
+  return {
+    currentStep,
+    isFirst: currentStepIndex === 0,
+    isLast: currentStepIndex === steps.length - 1,
+    next,
+    back,
+    reset,
+  };
+};
+
+export default useStepForm;

--- a/src/features/register/ui/FirstStep.tsx
+++ b/src/features/register/ui/FirstStep.tsx
@@ -1,0 +1,38 @@
+import RHFRadioGroup from "@/shared/ui/ui/RHFRadioGroup";
+import { registerSchema } from "../model/type";
+import { UseFormReturn } from "react-hook-form";
+
+interface FirstStepProps {
+  form: UseFormReturn<registerSchema>;
+}
+
+const FirstStep = ({ form }: FirstStepProps) => {
+  return (
+    <div className=" flex flex-col items-center gap-4 ">
+      <h1 className=" text-center text-2xl sm:text-3xl">
+        Check out before registration.
+      </h1>
+      <h1 className=" text-center text-xl font-bold sm:text-2xl text-[#415A77]">
+        Has the patient received neoadjuvant treatment?
+      </h1>
+      <div className=" flex w-full bg-[#F7F7F7] justify-center rounded-md">
+        <RHFRadioGroup
+          form={form}
+          name="isReceived"
+          options={[
+            {
+              label: "Yes, he/she has received neoadjuvant therapy.",
+              value: "yes",
+            },
+            {
+              label: "No, he/she has not received neoadjuvant therapy.",
+              value: "no",
+            },
+          ]}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default FirstStep;

--- a/src/features/register/ui/RegisterForm.tsx
+++ b/src/features/register/ui/RegisterForm.tsx
@@ -1,0 +1,92 @@
+// import { Form } from "@/shared/ui/shadcn/form";
+// import FirstStep from "./FirstStep";
+// import Stepper from "./Stepper";
+// import { useForm } from "react-hook-form";
+// import { z } from "zod";
+// import { zodResolver } from "@hookform/resolvers/zod";
+// import registerSchema from "../model/schema";
+// import SecondStep from "./SecondStep";
+
+// const RegisterForm = () => {
+//   const form = useForm<z.infer<typeof registerSchema>>({
+//     resolver: zodResolver(registerSchema),
+//   });
+
+//   const onSubmit = (value: z.infer<typeof registerSchema>) => {
+//     console.log(value);
+//   };
+
+//   return (
+//     <div>
+//       <Stepper />
+//       <Form {...form}>
+//         <form onSubmit={form.handleSubmit(onSubmit)}>
+//           <FirstStep form={form} />
+//           <SecondStep form={form} />
+//         </form>
+//       </Form>
+//     </div>
+//   );
+// };
+
+// export default RegisterForm;
+
+import { Form } from "@/shared/ui/shadcn/form";
+import FirstStep from "./FirstStep";
+import SecondStep from "./SecondStep";
+import Stepper from "./Stepper";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import registerSchema from "../model/schema";
+import useStepForm from "../model/useStepForm";
+import { Button } from "@/shared/ui/shadcn/button";
+
+const steps = ["first", "second"] as ("first" | "second")[];
+
+const RegisterForm = () => {
+  const form = useForm<z.infer<typeof registerSchema>>({
+    resolver: zodResolver(registerSchema),
+  });
+
+  const { currentStep, next, back, isFirst, isLast } =
+    useStepForm<(typeof steps)[number]>(steps);
+
+  const onSubmit = (value: z.infer<typeof registerSchema>) => {
+    console.log(value);
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* <Stepper currentStep={currentStep} steps={steps} /> */}
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit((data) => {
+            if (!isLast) {
+              console.log(data);
+              next();
+            } else {
+              onSubmit(data);
+            }
+          })}
+          className="space-y-4"
+        >
+          {currentStep === "first" && <FirstStep form={form} />}
+          {currentStep === "second" && <SecondStep form={form} />}
+
+          <div className="flex justify-between pt-4">
+            {!isFirst && (
+              <Button type="button" onClick={back}>
+                Back
+              </Button>
+            )}
+            {!isLast && <Button type="submit">Next</Button>}
+            {isLast && <Button type="submit">Submit</Button>}
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+};
+
+export default RegisterForm;

--- a/src/features/register/ui/RegisterForm.tsx
+++ b/src/features/register/ui/RegisterForm.tsx
@@ -1,40 +1,6 @@
-// import { Form } from "@/shared/ui/shadcn/form";
-// import FirstStep from "./FirstStep";
-// import Stepper from "./Stepper";
-// import { useForm } from "react-hook-form";
-// import { z } from "zod";
-// import { zodResolver } from "@hookform/resolvers/zod";
-// import registerSchema from "../model/schema";
-// import SecondStep from "./SecondStep";
-
-// const RegisterForm = () => {
-//   const form = useForm<z.infer<typeof registerSchema>>({
-//     resolver: zodResolver(registerSchema),
-//   });
-
-//   const onSubmit = (value: z.infer<typeof registerSchema>) => {
-//     console.log(value);
-//   };
-
-//   return (
-//     <div>
-//       <Stepper />
-//       <Form {...form}>
-//         <form onSubmit={form.handleSubmit(onSubmit)}>
-//           <FirstStep form={form} />
-//           <SecondStep form={form} />
-//         </form>
-//       </Form>
-//     </div>
-//   );
-// };
-
-// export default RegisterForm;
-
 import { Form } from "@/shared/ui/shadcn/form";
 import FirstStep from "./FirstStep";
 import SecondStep from "./SecondStep";
-import Stepper from "./Stepper";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/src/features/register/ui/RegisterForm.tsx
+++ b/src/features/register/ui/RegisterForm.tsx
@@ -14,6 +14,8 @@ import { ROUTES } from "@/shared/contants/routes";
 
 const RegisterForm = () => {
   const navigate = useNavigate();
+
+  // 작성한 zod schema object로부터 타입 추론
   const form = useForm<z.infer<typeof registerSchema>>({
     resolver: zodResolver(registerSchema),
   });
@@ -23,19 +25,23 @@ const RegisterForm = () => {
 
   const handleNext = async () => {
     const valid = await form.trigger(stepField[currentStep]);
-
     if (valid) {
+      // 해당 feild에 대한 비동기 유효성 검사
       next();
     }
   };
 
   const onSubmit = (value: z.infer<typeof registerSchema>) => {
+    /** todos :
+     * submit 비즈니스 로직 추가
+     */
     console.log(value);
   };
 
   return (
     <div className="space-y-4">
-      {/* <Stepper currentStep={currentStep} steps={steps} /> */}
+      {/* todos : 단계별 stepper UI */}
+      {/* <Stepper currentStep={currentStep} steps={steps} />  */}
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit((data) => {

--- a/src/features/register/ui/RegisterForm.tsx
+++ b/src/features/register/ui/RegisterForm.tsx
@@ -41,21 +41,13 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import registerSchema from "../model/schema";
 import useStepForm from "../model/useStepForm";
 import { Button } from "@/shared/ui/shadcn/button";
-
-const steps = ["first", "second"] as ("first" | "second")[];
+import ThirdStep from "./ThirdStep";
+import { STEP, stepField, steps } from "../model/type";
 
 const RegisterForm = () => {
   const form = useForm<z.infer<typeof registerSchema>>({
     resolver: zodResolver(registerSchema),
   });
-
-  const stepField: Record<
-    (typeof steps)[number],
-    (keyof z.infer<typeof registerSchema>)[]
-  > = {
-    first: ["isReceived"],
-    second: ["patientId", "patientName", "isMale", "birthday", "operationDate"],
-  };
 
   const { currentStep, next, back, isFirst, isLast } =
     useStepForm<(typeof steps)[number]>(steps);
@@ -87,8 +79,10 @@ const RegisterForm = () => {
           })}
           className="space-y-4"
         >
-          {currentStep === "first" && <FirstStep form={form} />}
-          {currentStep === "second" && <SecondStep form={form} />}
+          {/* 단계별 form 스텝 */}
+          {currentStep === STEP.FIRST && <FirstStep form={form} />}
+          {currentStep === STEP.SECOND && <SecondStep form={form} />}
+          {currentStep === STEP.THIRD && <ThirdStep form={form} />}
 
           <div className="flex justify-between pt-4">
             {!isFirst && (

--- a/src/features/register/ui/RegisterForm.tsx
+++ b/src/features/register/ui/RegisterForm.tsx
@@ -49,8 +49,24 @@ const RegisterForm = () => {
     resolver: zodResolver(registerSchema),
   });
 
+  const stepField: Record<
+    (typeof steps)[number],
+    (keyof z.infer<typeof registerSchema>)[]
+  > = {
+    first: ["isReceived"],
+    second: ["patientId", "patientName", "isMale", "birthday", "operationDate"],
+  };
+
   const { currentStep, next, back, isFirst, isLast } =
     useStepForm<(typeof steps)[number]>(steps);
+
+  const handleNext = async () => {
+    const valid = await form.trigger(stepField[currentStep]);
+
+    if (valid) {
+      next();
+    }
+  };
 
   const onSubmit = (value: z.infer<typeof registerSchema>) => {
     console.log(value);
@@ -80,7 +96,11 @@ const RegisterForm = () => {
                 Back
               </Button>
             )}
-            {!isLast && <Button type="submit">Next</Button>}
+            {!isLast && (
+              <Button type="button" onClick={handleNext}>
+                Next
+              </Button>
+            )}
             {isLast && <Button type="submit">Submit</Button>}
           </div>
         </form>

--- a/src/features/register/ui/RegisterForm.tsx
+++ b/src/features/register/ui/RegisterForm.tsx
@@ -9,8 +9,11 @@ import useStepForm from "../model/useStepForm";
 import { Button } from "@/shared/ui/shadcn/button";
 import ThirdStep from "./ThirdStep";
 import { STEP, stepField, steps } from "../model/type";
+import { useNavigate } from "react-router-dom";
+import { ROUTES } from "@/shared/contants/routes";
 
 const RegisterForm = () => {
+  const navigate = useNavigate();
   const form = useForm<z.infer<typeof registerSchema>>({
     resolver: zodResolver(registerSchema),
   });
@@ -51,7 +54,11 @@ const RegisterForm = () => {
           {currentStep === STEP.THIRD && <ThirdStep form={form} />}
 
           <div className="flex justify-between pt-4">
-            {!isFirst && (
+            {isFirst ? (
+              <Button type="button" onClick={() => navigate(ROUTES.ROOT)}>
+                Back
+              </Button>
+            ) : (
               <Button type="button" onClick={back}>
                 Back
               </Button>

--- a/src/features/register/ui/SecondStep.tsx
+++ b/src/features/register/ui/SecondStep.tsx
@@ -1,0 +1,63 @@
+import RHFInput from "@/shared/ui/ui/RHFInput";
+import { UseFormReturn } from "react-hook-form";
+import { registerSchema } from "../model/type";
+import RHFRadioGroup from "@/shared/ui/ui/RHFRadioGroup";
+
+interface SecondStepProps {
+  form: UseFormReturn<registerSchema>;
+}
+
+const SecondStep = ({ form }: SecondStepProps) => {
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-center text-2xl sm:text-3xl mb-4">
+        Now, register new participant.
+      </h1>
+      <RHFInput
+        form={form}
+        label="Patient ID"
+        name="patientId"
+        placeholder="Patient Id"
+        type="text"
+      />
+      <RHFInput
+        form={form}
+        label="Patient Name"
+        name="patientName"
+        placeholder="patient Name"
+        type="text"
+      />
+      <RHFRadioGroup
+        form={form}
+        name="isMale"
+        label="Sex"
+        flex
+        options={[
+          { label: "Male", value: "Male" },
+          { label: "Female", value: "Female" },
+        ]}
+      />
+      <RHFInput
+        form={form}
+        type="date"
+        name="birthday"
+        label="Birthday"
+        placeholder=""
+        className="flex justify-between"
+      />
+      <RHFInput
+        form={form}
+        type="date"
+        name="operationDate"
+        label="Operation Date"
+        placeholder=""
+        className="flex justify-between"
+      />
+      <h2 className="text-md text-center text-[#415A77]">
+        After entering the data, click “Next”.
+      </h2>
+    </div>
+  );
+};
+
+export default SecondStep;

--- a/src/features/register/ui/Stepper.tsx
+++ b/src/features/register/ui/Stepper.tsx
@@ -1,0 +1,5 @@
+const Stepper = () => {
+  return <div>Stepper</div>;
+};
+
+export default Stepper;

--- a/src/features/register/ui/ThirdStep.tsx
+++ b/src/features/register/ui/ThirdStep.tsx
@@ -1,0 +1,5 @@
+const ThirdStep = () => {
+  return <div>ThirdStep</div>;
+};
+
+export default ThirdStep;

--- a/src/features/register/ui/ThirdStep.tsx
+++ b/src/features/register/ui/ThirdStep.tsx
@@ -1,5 +1,39 @@
-const ThirdStep = () => {
-  return <div>ThirdStep</div>;
+import { UseFormReturn } from "react-hook-form";
+import { registerSchema } from "../model/type";
+
+interface ThirdStepProps {
+  form: UseFormReturn<registerSchema>;
+}
+
+const ThirdStep = ({ form }: ThirdStepProps) => {
+  const values = form.getValues();
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold text-center">
+        Confirm Your Information
+      </h2>
+
+      <div className="space-y-2 bg-gray-50 p-4 rounded-md shadow">
+        <InfoItem
+          label="Is Received"
+          value={values.isReceived ? "Yes" : "No"}
+        />
+        <InfoItem label="Patient ID" value={values.patientId} />
+        <InfoItem label="Patient Name" value={values.patientName} />
+        <InfoItem label="Sex" value={values.isMale ? "Male" : "Female"} />
+        <InfoItem label="Birthday" value={values.birthday} />
+        <InfoItem label="Operation Date" value={values.operationDate} />
+      </div>
+    </div>
+  );
 };
+
+const InfoItem = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex justify-between text-sm">
+    <span className="font-semibold">{label}</span>
+    <span>{value}</span>
+  </div>
+);
 
 export default ThirdStep;

--- a/src/pages/register/index.tsx
+++ b/src/pages/register/index.tsx
@@ -1,5 +1,7 @@
+import RegisterForm from "@/features/register/ui/RegisterForm";
+
 const Register = () => {
-  return <div>Register</div>;
+  return <RegisterForm />;
 };
 
 export default Register;

--- a/src/shared/ui/shadcn/checkbox.tsx
+++ b/src/shared/ui/shadcn/checkbox.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/shared/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/shared/ui/shadcn/radio-group.tsx
+++ b/src/shared/ui/shadcn/radio-group.tsx
@@ -1,0 +1,43 @@
+import * as React from "react"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { CircleIcon } from "lucide-react"
+
+import { cn } from "@/shared/lib/utils"
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/src/shared/ui/ui/RHFInput.tsx
+++ b/src/shared/ui/ui/RHFInput.tsx
@@ -30,17 +30,19 @@ const RHFInput = <T extends FieldValues>({
       control={form.control}
       name={name}
       render={({ field }) => (
-        <FormItem className="flex gap-2 items-center">
-          <FormLabel className="w-[100px] font-bold">{label}</FormLabel>
-          <FormControl>
-            <Input
-              type={type}
-              placeholder={placeholder}
-              {...field}
-              className={className}
-            />
-          </FormControl>
-          <FormMessage />
+        <FormItem className="flex flex-col gap-0">
+          <div className="flex gap-2 items-center">
+            <FormLabel className="w-[100px] font-bold">{label}</FormLabel>
+            <FormControl>
+              <Input
+                type={type}
+                placeholder={placeholder}
+                {...field}
+                className={className}
+              />
+            </FormControl>
+          </div>
+          <FormMessage className=" text-end" />
         </FormItem>
       )}
     />

--- a/src/shared/ui/ui/RHFInput.tsx
+++ b/src/shared/ui/ui/RHFInput.tsx
@@ -1,30 +1,46 @@
-import { z } from "zod";
-import { FormControl, FormField, FormItem, FormLabel } from "../shadcn/form";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "../shadcn/form";
 import { Input } from "../shadcn/input";
-import formSchema from "@/features/sign/model/schema";
-import { UseFormReturn } from "react-hook-form";
+import { UseFormReturn, FieldValues, Path } from "react-hook-form";
 
-type FormSchema = z.infer<typeof formSchema>;
-
-interface RHFInputProps {
-  form: UseFormReturn<FormSchema>;
-  name: keyof FormSchema;
+interface RHFInputProps<T extends FieldValues> {
+  form: UseFormReturn<T>;
+  name: Path<T>;
   placeholder: string;
   label: string;
   type: string;
+  className?: string;
 }
 
-const RHFInput = ({ form, name, placeholder, label, type }: RHFInputProps) => {
+const RHFInput = <T extends FieldValues>({
+  form,
+  name,
+  placeholder,
+  label,
+  type,
+  className = "",
+}: RHFInputProps<T>) => {
   return (
     <FormField
       control={form.control}
       name={name}
       render={({ field }) => (
-        <FormItem className=" flex gap-2 items-center">
-          <FormLabel className=" w-[100px] font-bold">{label}</FormLabel>
+        <FormItem className="flex gap-2 items-center">
+          <FormLabel className="w-[100px] font-bold">{label}</FormLabel>
           <FormControl>
-            <Input type={type} placeholder={placeholder} {...field} />
+            <Input
+              type={type}
+              placeholder={placeholder}
+              {...field}
+              className={className}
+            />
           </FormControl>
+          <FormMessage />
         </FormItem>
       )}
     />

--- a/src/shared/ui/ui/RHFRadioGroup.tsx
+++ b/src/shared/ui/ui/RHFRadioGroup.tsx
@@ -1,0 +1,64 @@
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "../shadcn/form";
+import { UseFormReturn, FieldValues, Path } from "react-hook-form";
+import { RadioGroup, RadioGroupItem } from "../shadcn/radio-group";
+import { ReactNode } from "react";
+
+interface RHFRadioGroupProps<T extends FieldValues> {
+  form: UseFormReturn<T>;
+  name: Path<T>;
+  label?: string | null | ReactNode;
+  flex?: boolean;
+  options: {
+    label: string;
+    value: string;
+  }[];
+}
+
+const RHFRadioGroup = <T extends FieldValues>({
+  form,
+  name,
+  label,
+  options,
+  flex = false,
+}: RHFRadioGroupProps<T>) => {
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className={`flex items-center`}>
+          <FormLabel className={`font-bold ${flex ? "w-[100px]" : ""}`}>
+            {label}
+          </FormLabel>
+          <FormControl>
+            <RadioGroup
+              onValueChange={field.onChange}
+              value={field.value}
+              className={`flex ${
+                flex ? "justify-center w-full" : "flex-col justify-center"
+              }  bg-[#F7F7F7] rounded-md py-2 `}
+            >
+              {options.map((option) => (
+                <FormItem key={option.value} className="flex items-center">
+                  <FormControl>
+                    <RadioGroupItem value={option.value} />
+                  </FormControl>
+                  <FormLabel className="font-normal">{option.label}</FormLabel>
+                </FormItem>
+              ))}
+            </RadioGroup>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};
+
+export default RHFRadioGroup;


### PR DESCRIPTION
### Register Page UI

단계별로 나누어진 Form 양식을 커스텀 혹으로 관리

```
import { useState } from "react";

const useStepForm = <T extends string>(steps: T[]) => {
  const [currentStepIndex, setCurrentStepIndex] = useState(0);

  const next = () => {
    setCurrentStepIndex((prev) => Math.min(prev + 1, steps.length - 1));
  };

  const back = () => {
    setCurrentStepIndex((prev) => Math.max(prev - 1, 0));
  };

  const reset = () => setCurrentStepIndex(0);

  const currentStep = steps[currentStepIndex];

  return {
    currentStep,
    isFirst: currentStepIndex === 0,
    isLast: currentStepIndex === steps.length - 1,
    next,
    back,
    reset,
  };
};

export default useStepForm;
```
커스텀 훅에서 현재 step을 state로 관리

```
import { z } from "zod";
import registerSchema from "./schema";

export type registerSchema = z.infer<typeof registerSchema>;

export const STEP = {
  FIRST: "first",
  SECOND: "second",
  THIRD: "third",
};

export const steps = [STEP.FIRST, STEP.SECOND, STEP.THIRD] as (
  | "first"
  | "second"
  | "third"
)[];

export const stepField: Record<
  (typeof steps)[number],
  (keyof z.infer<typeof registerSchema>)[]
> = {
  first: ["isReceived"],
  second: ["patientId", "patientName", "isMale", "birthday", "operationDate"],
  third: [],
};
```
register/model/type.ts에서
각 단계별 feild를 분리
